### PR TITLE
Update Maid

### DIFF
--- a/Maid.d.ts
+++ b/Maid.d.ts
@@ -4,7 +4,7 @@ declare namespace Maid {
 	export interface Destroyable {
 		Destroy(): void;
 	}
-	export type Task = (() => any) | RBXScriptConnection | Maid | Maid.Destroyable;
+	export type Task = (() => any) | thread | RBXScriptConnection | Maid | Maid.Destroyable;
 }
 
 type Maid = {
@@ -14,6 +14,7 @@ type Maid = {
 	 * Adds a task to perform.
 	 * Tasks can be:
 	 * - a function
+	 * - a thread
 	 * - a RBXScriptConnection
 	 * - a Maid
 	 * - an object with a Destroy() method

--- a/Maid.lua
+++ b/Maid.lua
@@ -54,7 +54,18 @@ function Maid:__newindex(index, newTask)
 		if type(oldTask) == "function" then
 			oldTask()
 		elseif type(oldTask) == "thread" then
-			task.cancel(oldTask)
+			local cancelled
+			if coroutine.running() ~= oldTask then
+				cancelled = pcall(function()
+					task.cancel(oldTask)
+				end)
+			end
+
+			if not cancelled then
+				task.defer(function()
+					task.cancel(oldTask)
+				end)
+			end
 		elseif typeof(oldTask) == "RBXScriptConnection" then
 			oldTask:Disconnect()
 		elseif oldTask.Destroy then
@@ -115,7 +126,19 @@ function Maid:DoCleaning()
 		if type(job) == "function" then
 			job()
 		elseif type(job) == "thread" then
-			task.cancel(job)
+			local cancelled
+			if coroutine.running() ~= job then
+				cancelled = pcall(function()
+					task.cancel(job)
+				end)
+			end
+
+			if not cancelled then
+				local toCancel = job
+				task.defer(function()
+					task.cancel(toCancel)
+				end)
+			end
 		elseif typeof(job) == "RBXScriptConnection" then
 			job:Disconnect()
 		elseif job.Destroy then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,30 @@
 {
-  "name": "@rbxts/maid",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@rbxts/types": {
-      "version": "1.0.320",
-      "resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.320.tgz",
-      "integrity": "sha512-ogcKI/DswSdQFPE45y/fNLlZ4wBl8XqxrS6zvrd0+hzLTpO898XiscWaKGJ2r9KdFo9KI3YFz3dQxF7EdQCaJQ==",
-      "dev": true
-    }
-  }
+	"name": "@rbxts/maid",
+	"version": "1.0.0-ts.1",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@rbxts/maid",
+			"version": "1.0.0-ts.1",
+			"license": "ISC",
+			"devDependencies": {
+				"@rbxts/types": "^1.0.320"
+			}
+		},
+		"node_modules/@rbxts/types": {
+			"version": "1.0.320",
+			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.320.tgz",
+			"integrity": "sha512-ogcKI/DswSdQFPE45y/fNLlZ4wBl8XqxrS6zvrd0+hzLTpO898XiscWaKGJ2r9KdFo9KI3YFz3dQxF7EdQCaJQ==",
+			"dev": true
+		}
+	},
+	"dependencies": {
+		"@rbxts/types": {
+			"version": "1.0.320",
+			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.320.tgz",
+			"integrity": "sha512-ogcKI/DswSdQFPE45y/fNLlZ4wBl8XqxrS6zvrd0+hzLTpO898XiscWaKGJ2r9KdFo9KI3YFz3dQxF7EdQCaJQ==",
+			"dev": true
+		}
+	}
 }


### PR DESCRIPTION
This PR is for to update the Maid library to update my `@rbxts/binder` package (which it depends on)
because there is a [code in Binder](https://github.com/Quenty/NevermoreEngine/blob/main/src/binder/src/Shared/Binder.lua#L81) where it uses Maid to cancel any threads at any time.

**There are changes that made to Maid (Nevermore variant):**
- Add thread support for maids (it will cancel a thread upon being destroyed or having an old task to clean up)
- Changed maid error message
- Modified 'task' variable from Maid:DoCleaning to 'job'
- Fix thread cancellation bug from both `Maid.__newindex()` and `Maid:DoCleaning()`